### PR TITLE
optimise dockerfile with multi stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM myobplatform/shell-operator:0.1.0 as shop
 
-FROM python:3.6-alpine as py-builder
+FROM python:3.7-alpine3.8 as py-builder
 RUN apk add --no-cache -U git gcc musl-dev libffi-dev openssl-dev make
 RUN mkdir /install
 WORKDIR /install
 COPY opt/ansible-runner/requirements.txt /opt/ansible-runner/requirements.txt
-RUN export PYTHONPATH="/install/lib/python3.6/site-packages" && \
+RUN export PYTHONPATH="/install/lib/python3.7/site-packages" && \
     pip install --install-option="--prefix=/install" -r /opt/ansible-runner/requirements.txt
 
-FROM python:3.6-alpine as base
+FROM python:3.7-alpine3.8 as base
 RUN apk add --no-cache -U curl bash
 ENV KUBE_VERSION="v1.11.3"
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/bin/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY opt/ansible-runner/requirements.txt /opt/ansible-runner/requirements.txt
 RUN export PYTHONPATH="/install/lib/python3.6/site-packages" && \
     pip install --install-option="--prefix=/install" -r /opt/ansible-runner/requirements.txt
 
-FROM alpine as base
+FROM python:3.6-alpine as base
 RUN apk add --no-cache -U curl bash
 ENV KUBE_VERSION="v1.11.3"
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/bin/kubectl \

--- a/bin/test
+++ b/bin/test
@@ -15,5 +15,5 @@ export TEST_ACTION=$action
 docker build -t myobplatform/ansible-runner:latest .
 cd test
 docker-compose build
-docker-compose up test
+docker-compose run test
 docker-compose down

--- a/bin/test
+++ b/bin/test
@@ -12,7 +12,7 @@ action="$1"
 [[ "$action" =~ ^(upsert|delete)$ ]] || die "argument must be one of upsert or delete"
 
 export TEST_ACTION=$action
-docker build -t myobplatform/ansible-runner:latest .
+docker build -t ansible-runner:latest .
 cd test
 docker-compose build
 docker-compose run test

--- a/opt/ansible-runner/requirements.txt
+++ b/opt/ansible-runner/requirements.txt
@@ -1,4 +1,4 @@
 boto==2.49.0
 boto3==1.9.14
 openshift==0.7.2
--e git+https://github.com/ansible/ansible.git@stable-2.7#egg=ansible==2.7.0
+ansible==2.7.0


### PR DESCRIPTION
This PR will optimise Dockerfile in Python build section via multi-stage build. 

With the updated Dockerfile, we can reduce image size to 325MB which is 51.5% size of original 631MB, while retaining same functionalities. 