### PR TITLE
Enable different tasks directory to be provided

### DIFF
--- a/opt/ansible-runner/ansible/roles/service/tasks/main.yml
+++ b/opt/ansible-runner/ansible/roles/service/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
-- include: /app/upsert.yml
+- name: "Validating that I have minimum required params"
+  assert:
+    that:
+    - "{{ 'tasks_dir' }} != ''"
+    msg: "Validating passed"
+
+- include: "{{ tasks_dir }}/upsert.yml"
   when: "k8s_resource is defined and delete_timestamp is not defined"
 
-- include: /app/delete.yml
+- include: "{{ tasks_dir }}/delete.yml"
   when: "k8s_resource is not defined or delete_timestamp is defined"

--- a/opt/ansible-runner/ansible/roles/service/tasks/main.yml
+++ b/opt/ansible-runner/ansible/roles/service/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
-- name: "Validating that I have minimum required params"
+- name: "Get tasks directory from environment variable"
+  set_fact:
+    tasks_dir: "{{ lookup('env','TASKS_DIR') | default('/app', true) }}"
+
+- name: "Validating task dir is valid"
   assert:
     that:
-    - "{{ 'tasks_dir' }} != ''"
+      - "'{{ tasks_dir }}' is directory"
+      - "'{{ tasks_dir }}/upsert.yml' is exists"
+      - "'{{ tasks_dir }}/delete.yml' is exists"
     msg: "Validating passed"
 
 - include: "{{ tasks_dir }}/upsert.yml"

--- a/opt/ansible-runner/bin/wrapper
+++ b/opt/ansible-runner/bin/wrapper
@@ -6,14 +6,10 @@ die() { printf '%s\n' "$*" >&2; exit 1; }
 
 pid=$$
 scriptdir=$(dirname $0)
-tasksdir="${1:-/app}"
 
 echo "+++ begin wrapper pid: $pid"
 
-[[ -d "${tasksdir}" ]] || die "directory '${tasksdir}' does not exist"
-[[ -f "${tasksdir}/upsert.yml" ]] || die "play upsert.yml does not exist"
-[[ -f "${tasksdir}/delete.yml" ]] || die "play delete.yml does not exist"
 cd ${scriptdir}/../ansible
 [[ -f "runner.yml" ]] || die "playbook runner.yml does not exist"
-ansible-playbook -e "tasks_dir=${tasksdir}" -v runner.yml
+ansible-playbook -v runner.yml
 echo "+++ end wrapper pid: $pid"

--- a/opt/ansible-runner/bin/wrapper
+++ b/opt/ansible-runner/bin/wrapper
@@ -6,11 +6,14 @@ die() { printf '%s\n' "$*" >&2; exit 1; }
 
 pid=$$
 scriptdir=$(dirname $0)
+tasksdir="${1:-/app}"
 
 echo "+++ begin wrapper pid: $pid"
-[[ -f "/app/upsert.yml" ]] || die "play upsert.yml does not exist"
-[[ -f "/app/delete.yml" ]] || die "play delete.yml does not exist"
+
+[[ -d "${tasksdir}" ]] || die "directory '${tasksdir}' does not exist"
+[[ -f "${tasksdir}/upsert.yml" ]] || die "play upsert.yml does not exist"
+[[ -f "${tasksdir}/delete.yml" ]] || die "play delete.yml does not exist"
 cd ${scriptdir}/../ansible
 [[ -f "runner.yml" ]] || die "playbook runner.yml does not exist"
-ansible-playbook -v runner.yml
+ansible-playbook -e "tasks_dir=${tasksdir}" -v runner.yml
 echo "+++ end wrapper pid: $pid"

--- a/test/app/another-tasks-dir/crd.yaml
+++ b/test/app/another-tasks-dir/crd.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: exampleresources.shop.example.com
+spec:
+  group: shop.example.com
+  names:
+    kind: ExampleResource
+    plural: exampleresources
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test/app/another-tasks-dir/delete.yml
+++ b/test/app/another-tasks-dir/delete.yml
@@ -1,0 +1,13 @@
+---
+
+- name: delete an example resource
+  debug:
+    msg: "a resource should get deleted now"
+
+- assert:
+    that:
+      - "obj_api_version == 'v1beta1'"
+      - "obj_kind == 'exampleresource'"
+      - "obj_namespace == 'default'"
+      - "obj_name == 'exampleresource-sample'"
+    msg: "object assertion failed"

--- a/test/app/another-tasks-dir/example-resource.yaml
+++ b/test/app/another-tasks-dir/example-resource.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: shop.example.com/v1beta1
+kind: ExampleResource
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: exampleresource-sample
+spec:
+  # Add fields here
+  specfield1: foo
+  specfield2: bar
+

--- a/test/app/another-tasks-dir/shell-config.yaml
+++ b/test/app/another-tasks-dir/shell-config.yaml
@@ -1,0 +1,8 @@
+---
+boot:
+  - command: kubectl apply -f /app/another-tasks-dir/crd.yaml
+watch:
+  - apiVersion: shop.example.com/v1beta1
+    kind: ExampleResource
+    command: /app/bin/wrapper "/app/another-tasks-dir"
+    concurrency: 5

--- a/test/app/another-tasks-dir/upsert.yml
+++ b/test/app/another-tasks-dir/upsert.yml
@@ -1,0 +1,26 @@
+---
+
+- name: upsert an example resource
+  debug:
+    msg: "a resource should get created or updated now"
+
+- assert:
+    that:
+      - "obj_api_version == 'v1beta1'"
+      - "obj_kind == 'exampleresource'"
+      - "obj_namespace == 'default'"
+      - "obj_name == 'exampleresource-sample'"
+    msg: "object assertion failed"
+
+- name: update the example resource
+  k8s:
+    state: present
+    definition:
+      apiVersion: "{{ obj_api_version }}"
+      kind: "{{ obj_kind }}"
+      metadata:
+        name: "{{ obj_name }}"
+        namespace: "{{ obj_namespace }}"
+      status:
+        statusfield1: "{{ k8s_resource.spec.specfield1 }}"
+        statusfield2: "{{ k8s_resource.spec.specfield2 }}"

--- a/test/app/shell-config.yaml
+++ b/test/app/shell-config.yaml
@@ -1,6 +1,6 @@
 ---
 boot:
-  - command: kubectl apply -f /app/config/crd.yaml
+  - command: kubectl apply -f /app/crd.yaml
 watch:
   - apiVersion: shop.example.com/v1beta1
     kind: ExampleResource

--- a/test/bin/test
+++ b/test/bin/test
@@ -13,4 +13,5 @@ export SHOP_OBJECT_NAME SHOP_OBJECT_NAMESPACE SHOP_KIND SHOP_API_VERSION
 /opt/ansible-runner/bin/wrapper
 
 # Test using different tasks directory
-/opt/ansible-runner/bin/wrapper "/app/another-tasks-dir"
+export TASKS_DIR="/app/another-tasks-dir"
+/opt/ansible-runner/bin/wrapper

--- a/test/bin/test
+++ b/test/bin/test
@@ -9,4 +9,8 @@ SHOP_KIND="exampleresource"
 
 export SHOP_OBJECT_NAME SHOP_OBJECT_NAMESPACE SHOP_KIND SHOP_API_VERSION
 
+# Test using default "/app" tasks directory
 /opt/ansible-runner/bin/wrapper
+
+# Test using different tasks directory
+/opt/ansible-runner/bin/wrapper "/app/another-tasks-dir"


### PR DESCRIPTION
This PR will:
- allow a different `tasks_dir` to be provided when executing `ansible-runner`
- default to existing `/app` directory if not provided